### PR TITLE
Fix validate-schema entry point configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -25,7 +25,7 @@
 - id: validate-schema
   name: Validate Database Schema (Multi-Dialect)
   description: Validates database schema files for compliance with RDBMS dialects and naming conventions
-  entry: hooks/validate_schema.py
+  entry: validate-schema
   language: python
   types: [json]
   require_serial: true

--- a/hooks/__init__.py
+++ b/hooks/__init__.py
@@ -1,0 +1,1 @@
+# Pre-commit check hooks package

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,38 @@
+[metadata]
+name = pre_commit_check_hooks
+version = 1.0.4
+description = Pre-commit hooks for checking code quality without modifications
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/Hernan-V/pre-commit-check-hooks
+author = Hernan Valenzuela
+author_email = hernan.valenzuela@example.com
+license = MIT
+license_files = LICENSE
+classifiers =
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Topic :: Software Development :: Quality Assurance
+    Intended Audience :: Developers
+
+[options]
+packages = find:
+install_requires =
+    case-converter>=1.1.0
+python_requires = >=3.7
+
+[options.packages.find]
+exclude =
+    tests*
+
+[options.entry_points]
+console_scripts =
+    validate-schema = hooks.validate_schema:main
+
+[bdist_wheel]
+universal = True

--- a/setup.py
+++ b/setup.py
@@ -2,30 +2,4 @@ from __future__ import annotations
 
 from setuptools import setup
 
-setup(
-    name='pre-commit-check-hooks',
-    version='1.0.0',
-    author='Hernan Valenzuela',
-    author_email='hernan.valenzuela@example.com',
-    description=(
-        'Pre-commit hooks for checking code quality without modifications'
-    ),
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    url='https://github.com/Hernan-V/pre-commit-check-hooks',
-    classifiers=[
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Topic :: Software Development :: Quality Assurance',
-        'Intended Audience :: Developers',
-    ],
-    install_requires=[
-        'case-converter>=1.1.0',
-    ],
-    python_requires='>=3.7',
-)
+setup()


### PR DESCRIPTION
- Add setup.cfg with proper console_scripts entry point
- Add __init__.py to make hooks a proper Python package
- Update .pre-commit-hooks.yaml to use entry point name instead of direct path
- Simplify setup.py to use setup.cfg configuration

This fixes the 'Executable hooks/validate_schema.py not found' error.