### PR TITLE
Fix validate-schema entry point configuration

### DIFF
--- a/hooks/validate_schema.py
+++ b/hooks/validate_schema.py
@@ -7,9 +7,9 @@ import os
 import sys
 from typing import Any
 
-from naming_utils import convert_naming_convention
-from naming_utils import get_supported_case_styles
-from naming_utils import validate_naming_convention
+from .naming_utils import convert_naming_convention
+from .naming_utils import get_supported_case_styles
+from .naming_utils import validate_naming_convention
 
 
 # Dialect Configuration System


### PR DESCRIPTION
## Summary
- Add setup.cfg with proper console_scripts entry point for validate-schema
- Add __init__.py to make hooks a proper Python package  
- Update .pre-commit-hooks.yaml to use entry point name instead of direct path
- Fix relative imports in validate_schema.py for proper package structure
- Simplify setup.py to use setup.cfg configuration

## Problem Solved
Fixes the error: `Executable hooks/validate_schema.py not found` when running pre-commit hooks.

## Test Plan
- [x] Test local import: `python -c "from hooks.validate_schema import main"`
- [x] Test module execution: `python -m hooks.validate_schema --help`
- [ ] Test pre-commit hook execution after merge