### PR TITLE
fix: correct absolute imports in validate_schema.py

### DIFF
--- a/hooks/validate_schema.py
+++ b/hooks/validate_schema.py
@@ -7,10 +7,10 @@ import os
 import sys
 from typing import Any
 
-from dialect_config import DIALECT_CONFIG
-from naming_utils import convert_naming_convention
-from naming_utils import get_supported_case_styles
-from naming_utils import validate_naming_convention
+from hooks.dialect_config import DIALECT_CONFIG
+from hooks.naming_utils import convert_naming_convention
+from hooks.naming_utils import get_supported_case_styles
+from hooks.naming_utils import validate_naming_convention
 
 
 # Dialect configurations are now imported from dialect_config.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pre_commit_check_hooks
-version = 1.0.4
+version = 1.0.6
 description = Pre-commit hooks for checking code quality without modifications
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Summary
- Change relative imports to absolute imports from hooks.*
- Fixes ModuleNotFoundError for dialect_config and naming_utils  
- Update version to 1.0.6

## Problem solved
Fixes the import error that caused the validate-schema hook to fail in pre-commit environment with:
```
ModuleNotFoundError: No module named 'dialect_config'
```

## Changes made
- hooks/validate_schema.py: Update imports to use absolute paths
- setup.cfg: Update version to 1.0.6